### PR TITLE
Clean itself too.

### DIFF
--- a/tape.css
+++ b/tape.css
@@ -18,6 +18,7 @@
   color: var(--tape-hex, var(--tape-white)) !important;
 }
 
+.tape-clean:not(.tape-unclean),
 .tape-clean :not(.tape-unclean) {
   background: transparent;
   color: inherit;


### PR DESCRIPTION
- Adds ability for `.tape-clean` to clean self unless combined with more `!important` rules
- Accurately wordable as <q>within</q> like the `flat` selector already was
  - `.tape-clean` Override coloring within
  - `.tape-unclean` Override `.tape-clean` on specific element
  - `.tape-flat` Transparentize borders within
  - `.tape-unflat` Override `.tape-flat` on specific element