### PR TITLE
0.1.0 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@s9a/tape",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s9a/tape",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Colors that stick.",
   "main": "tape.css",
   "license": "ISC",


### PR DESCRIPTION
Bump via [`npm version minor`](https://docs.npmjs.com/cli/version) for [first release](https://github.com/s9a/tape/releases/tag/v0.1.0) [on npm](https://www.npmjs.com/package/@s9a/tape)