### PR TITLE
FYI npm publish --access=public

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@s9a/tape",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s9a/tape",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Colors that stick.",
   "main": "tape.css",
   "license": "ISC",


### PR DESCRIPTION
~Revert #9 because `pkg.private` defaults to `true` for orgs it seems~ [#issuecomment-413420021](#issuecomment-413420021)

#### `npm publish`

```
npm ERR! publish Failed PUT 402
npm ERR! code E402
npm ERR! You must sign up for private packages : @s9a/tape
```
