### PR TITLE
media respect

### DIFF
--- a/tape.css
+++ b/tape.css
@@ -1,5 +1,5 @@
 :root {
-  --tape-white: #f5f5f5;
+  --tape-white: #e9e9e9;
   --tape-black: #090909;
   --tape-pink: #fbbfff;
   --tape-yellow: #eee833;

--- a/tape.css
+++ b/tape.css
@@ -7,6 +7,13 @@
   --tape-green: #44f477;
 }
 
+@media (prefers-contrast: less) {
+  :root {
+    --tape-white: #dcdcdc;
+    --tape-black: #272727;
+  }
+}
+
 .tape-white { --tape-hex: var(--tape-white) }
 .tape-blue { --tape-hex: var(--tape-blue) }
 .tape-pink { --tape-hex: var(--tape-pink) }


### PR DESCRIPTION
* mild media query treatment to reduce contrast if you prefer less contrast
* dimmer default white to save a lil energy and because `whitesmoke` was too hot to handle
